### PR TITLE
feat: add hiraganaToKatakana

### DIFF
--- a/.changeset/add-hiragana-to-katakana.md
+++ b/.changeset/add-hiragana-to-katakana.md
@@ -1,0 +1,5 @@
+---
+'@birchill/normal-jp': minor
+---
+
+Add a `hiraganaToKatakana` function for converting hiragana to full-width katakana

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Note that the length of the output is equal to the length of the input so this
 function does not returning the mapping from input string character offsets to
 output string positions.
 
+## `hiraganaToKatakana`
+
+Converts hiragana characters to full-width katakana. As with
+`katakanaToHiragana` the length of the input and output is equal so this
+function does not return the mapping between character offsets.
+
 ## `kyuujitaiToShinjitai`
 
 Converts various 旧字体 (_kyuujitai_, old character forms) to 新字体 (_shinjitai_,

--- a/src/hiragana-to-katakana.test.ts
+++ b/src/hiragana-to-katakana.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { hiraganaToKatakana } from './hiragana-to-katakana.js';
+
+describe('hiraganaToKatakana', () => {
+  it('converts hiragana', () => {
+    expect(hiraganaToKatakana('がーでん')).toEqual('ガーデン');
+    expect(hiraganaToKatakana('ゔゕゖ')).toEqual('ヴヵヶ');
+  });
+
+  it('converts iteration marks', () => {
+    expect(hiraganaToKatakana('ゝゞ')).toEqual('ヽヾ');
+  });
+
+  it("does not convert hiragana which don't have katakana equivalents", () => {
+    expect(hiraganaToKatakana('ゟ・ーか')).toEqual('ゟ・ーカ');
+  });
+});

--- a/src/hiragana-to-katakana.ts
+++ b/src/hiragana-to-katakana.ts
@@ -1,0 +1,15 @@
+export function hiraganaToKatakana(input: string): string {
+  let result = '';
+
+  for (const char of input) {
+    let c = char.codePointAt(0)!;
+
+    if ((c >= 0x3041 && c <= 0x3096) || c === 0x309d || c === 0x309e) {
+      c += 0x60;
+    }
+
+    result += String.fromCodePoint(c);
+  }
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { expandChoon } from './expand-choon.js';
+export { hiraganaToKatakana } from './hiragana-to-katakana.js';
 export { kanaToHiragana } from './kana-to-hiragana.js';
 export { kyuujitaiToShinjitai } from './kyuujitai.js';
 export { halfToFullWidthNum } from './numbers.js';


### PR DESCRIPTION
Adds a `hiraganaToKatakana` function — the mirror of the existing `kanaToHiragana`.

It converts hiragana (`ぁ`–`ゖ`) and the hiragana iteration marks `ゝゞ` to their full-width katakana equivalents (`+0x60`), leaving everything else — including `ゟ` (U+309F), which has no single-character katakana equivalent — untouched.

### Why
Requested in the [referee #454 review](https://github.com/birchill/referee/pull/454#discussion_r3317573242): referee currently defines local `toKatakana`/`toHiragana` helpers in `src/tts/kana.ts`. With this published, referee can drop them in favour of `kanaToHiragana` + `hiraganaToKatakana` (tracked as TEN-423).

### Changes
- `src/hiragana-to-katakana.ts` — new function, styled to match `kana-to-hiragana.ts`
- `src/hiragana-to-katakana.test.ts` — mirrors the `kanaToHiragana` tests (incl. iteration marks + a passthrough case for `ゟ`)
- Exported from `src/index.ts`
- README section added
- Changeset (minor bump → 1.7.0)

### Verification
`pnpm build && pnpm test && pnpm knip` all pass locally (23 tests).

### Note (out of scope)
The README heading documents this family as `katakanaToHiragana`, but the actual export is `kanaToHiragana` — a pre-existing doc/code mismatch. Left as-is to keep this PR focused; happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)