### PR TITLE
Fix ー expansion for katakana ヒ and ビ

### DIFF
--- a/.changeset/yellow-weeks-draw.md
+++ b/.changeset/yellow-weeks-draw.md
@@ -1,0 +1,5 @@
+---
+'@birchill/normal-jp': patch
+---
+
+Fix expandChoon expansion for katakana ヒ and ビ

--- a/src/expand-choon.test.ts
+++ b/src/expand-choon.test.ts
@@ -13,6 +13,13 @@ describe('expandChoon', () => {
     expect(expandChoon('オーサカ')).toEqual(['オウサカ', 'オオサカ']);
   });
 
+  it('expands the i-row consistently for hiragana and katakana', () => {
+    expect(expandChoon('ひー')).toEqual(['ひい']);
+    expect(expandChoon('ヒーター')).toEqual(['ヒイタア']);
+    expect(expandChoon('びー')).toEqual(['びい']);
+    expect(expandChoon('ビール')).toEqual(['ビイル']);
+  });
+
   it('expands extended cases', () => {
     expect(expandChoon('わーーーーーい')).toEqual(['わあああああい']);
   });

--- a/src/expand-choon.ts
+++ b/src/expand-choon.ts
@@ -26,7 +26,7 @@ export function expandChoon(input: string): Array<string> {
     .replace(/([あかがさざただなはばぱまやゃらわ])ー+/g, replacer('あ'))
     .replace(/([アカガサザタダナハバパマヤャラワ])ー+/g, replacer('ア'))
     .replace(/([いきぎしじちぢにひびぴみり])ー+/g, replacer('い'))
-    .replace(/([イキギシジチヂニイブピミリ])ー+/g, replacer('イ'))
+    .replace(/([イキギシジチヂニヒビピミリ])ー+/g, replacer('イ'))
     .replace(/([えけげせぜてでねへべぺめれ])ー+/g, replacer('え'))
     .replace(/([エケゲセゼテデネヘベペメレ])ー+/g, replacer('エ'));
 


### PR DESCRIPTION
The katakana i-vowel row in `expandChoon` is missing `ヒ` and `ビ`.

The character class for the katakana i-row reads:

```
.replace(/([イキギシジチヂニイブピミリ])ー+/g, replacer('イ'))
```

Compared with the hiragana i-row right above it (`いきぎしじちぢにひびぴみり`), two entries are off: there is a second `イ` where `ヒ` should be, and a `ブ` (a u-row kana) where `ビ` should be. As a result a long vowel mark after `ヒ` or `ビ` is left unexpanded:

- `expandChoon('ヒーター')` returns `['ヒータア']` instead of `['ヒイタア']`
- `expandChoon('ビール')` is not expanded at all instead of returning `['ビイル']`

The hiragana equivalents `ひー` and `びー` already expand correctly, so the katakana row was just out of sync.

The fix replaces the erroneous `イブ` with `ヒビ`. The stray `ブ` never actually matched, because the `ウ`-row replacement two lines above already consumes `ブー`, so dropping it changes no output. Added a test covering the hiragana and katakana i-row together so they stay in sync.