### PR TITLE
chore: upgrade to pnpm 12 and track latest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Use `version: latest` in the pnpm setup steps so CI picks up pnpm 12 and future stable releases.

Validation with pnpm 12.3.4: `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm test`. Workflow YAML and `git diff --check` also pass.
